### PR TITLE
プレビュー画面で画面回転後にバックプレスの挙動がおかしくなる不具合修正

### DIFF
--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/App.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/App.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import jp.co.cyberagent.katalog.compose.page.DiscoveryPage
 import jp.co.cyberagent.katalog.compose.page.PreviewPage
 import jp.co.cyberagent.katalog.compose.res.materialColors
+import jp.co.cyberagent.katalog.compose.util.BackPressedEffect
 import jp.co.cyberagent.katalog.compose.widget.ModalVisibility
 import jp.co.cyberagent.katalog.ext.ExtRootWrapper
 
@@ -22,6 +23,10 @@ internal fun App(
     viewModel: KatalogViewModel = viewModel()
 ) {
     val darkTheme = isSystemInDarkTheme()
+
+    BackPressedEffect(Unit) {
+        viewModel.handleBackPress()
+    }
 
     MaterialTheme(
         colors = materialColors(darkTheme)

--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/KatalogViewModel.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/KatalogViewModel.kt
@@ -38,6 +38,15 @@ internal class KatalogViewModel : ViewModel() {
         }
     }
 
+    fun handleBackPress(): Boolean {
+        return if (_selectedComponent.value != null) {
+            _selectedComponent.value = null
+            true
+        } else {
+            navController.back()
+        }
+    }
+
     fun closePreview() {
         _selectedComponent.value = null
     }

--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/navigation/NavRoot.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/navigation/NavRoot.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
-import jp.co.cyberagent.katalog.compose.util.BackPressedEffect
 
 @Composable
 internal fun <T> NavRoot(
@@ -19,10 +18,6 @@ internal fun <T> NavRoot(
 ) {
     val current by navController.current
     val saveableStateHolder = rememberSaveableStateHolder()
-
-    BackPressedEffect(Unit) {
-        navController.back()
-    }
 
     AnimatedPage(current) {
         NavChild(

--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/page/PreviewPager.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/page/PreviewPager.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import jp.co.cyberagent.katalog.compose.KatalogViewModel
-import jp.co.cyberagent.katalog.compose.util.BackPressedEffect
 import jp.co.cyberagent.katalog.compose.widget.KatalogTopAppBar
 import jp.co.cyberagent.katalog.compose.widget.Preview
 import jp.co.cyberagent.katalog.domain.CatalogItem
@@ -25,10 +24,6 @@ internal fun PreviewPage(
 ) {
     val katalog by viewModel.katalog.collectAsState()
     val extensions = katalog?.extensions ?: return
-    BackPressedEffect(component) {
-        viewModel.closePreview()
-        true
-    }
     Column(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
* backPressedDispatcherは後に設置した方が呼ばれるが、画面回転時に復元する際にPreviewの方が先に呼ばれ、正しく動作しなかった
* ViewModel側でどの画面を戻すか判断する