### PR TITLE
Fix a bug in NavState restore

### DIFF
--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/navigation/NavController.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/navigation/NavController.kt
@@ -20,12 +20,7 @@ internal class NavController<T : NavDestination>(
         childNavController == null || childNavController.isTop
     }
 
-    private var isTransitioning = false
-
     fun push(destination: T) {
-        if (isTransitioning) return
-        isTransitioning = true
-
         val state = NavState.of(destination, _backStack.size)
         _backStack.add(state)
     }
@@ -54,9 +49,5 @@ internal class NavController<T : NavDestination>(
         return _backStack.any {
             it.key == state.key
         }
-    }
-
-    fun handleCompleteTransition() {
-        isTransitioning = false
     }
 }

--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/navigation/NavRoot.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/navigation/NavRoot.kt
@@ -4,11 +4,13 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.ui.Modifier
+import jp.co.cyberagent.katalog.compose.widget.ClickMask
 
 @ExperimentalAnimationApi
 @Composable
@@ -21,8 +23,7 @@ internal fun <T : NavDestination> NavRoot(
 
     AnimatedPage(
         targetState = navController.current,
-        transitionSpec = transitionSpec,
-        onComplete = navController::handleCompleteTransition
+        transitionSpec = transitionSpec
     ) {
         NavChild(
             navController = navController,
@@ -57,18 +58,16 @@ private fun <T : NavDestination> NavChild(
 private fun <T> AnimatedPage(
     targetState: NavState<T>,
     transitionSpec: AnimatedContentScope<NavState<T>>.() -> ContentTransform,
-    onComplete: () -> Unit = {},
     content: @Composable (state: NavState<T>) -> Unit
 ) {
     AnimatedContent(
         targetState = targetState,
         transitionSpec = transitionSpec
     ) {
-        LaunchedEffect(transition.currentState) {
-            if (transition.currentState == transition.targetState) {
-                onComplete()
-            }
-        }
         content(it)
+        ClickMask(
+            modifier = Modifier.fillMaxSize(),
+            enabled = it != targetState
+        )
     }
 }

--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/widget/ClickMask.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/widget/ClickMask.kt
@@ -1,0 +1,18 @@
+package jp.co.cyberagent.katalog.compose.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+
+@Composable
+internal fun ClickMask(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    if (!enabled) return
+    Box(
+        modifier = modifier
+            .pointerInput(Unit) { }
+    )
+}

--- a/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/widget/Preview.kt
+++ b/katalog/src/main/kotlin/jp/co/cyberagent/katalog/compose/widget/Preview.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import jp.co.cyberagent.katalog.domain.ExtWrapperScopeImpl
 import jp.co.cyberagent.katalog.domain.Extensions
@@ -40,7 +39,10 @@ internal fun Preview(
         ) {
             Scaler(scale) {
                 definition()
-                ClickMask(!clickable)
+                ClickMask(
+                    modifier = Modifier.fillMaxSize(),
+                    enabled = !clickable
+                )
             }
         }
     }
@@ -90,14 +92,4 @@ private fun Scaler(
             content()
         }
     }
-}
-
-@Composable
-private fun ClickMask(enabled: Boolean = false) {
-    if (!enabled) return
-    Box(
-        modifier = Modifier
-            .pointerInput(Unit) { }
-            .fillMaxSize()
-    )
 }

--- a/katalog/src/test/kotlin/jp/co/cyberagent/katalog/compose/navigation/ExtNavStateImplTest.kt
+++ b/katalog/src/test/kotlin/jp/co/cyberagent/katalog/compose/navigation/ExtNavStateImplTest.kt
@@ -120,6 +120,27 @@ internal class ExtNavStateImplTest {
     }
 
     @Test
+    fun restore_nested() = runBlockingTest {
+        val katalog = dummyKatalog {
+            group("Group1") {
+                group("Group2") {
+                    compose("Item") {
+                        Text(text = "Sample")
+                    }
+                }
+            }
+        }
+        val navController = createMainNavController()
+        val target = ExtNavStateImpl(
+            navController = navController,
+            katalog = katalog
+        )
+        val actual = target.restore(listOf("/", "/Group1", "/Group1/Group2"))
+        assertThat(actual).isTrue()
+        assertThat(target.backStack).isEqualTo(listOf("/", "/Group1", "/Group1/Group2"))
+    }
+
+    @Test
     fun restore_invalid() = runBlockingTest {
         val katalog = dummyKatalog {
             group("Group") {


### PR DESCRIPTION
* Control to prevent double taps made a bug in NavState restore.
* Change the method of double taps control by using ClickMask.